### PR TITLE
[buteo-mtp] Use lcMtp logging category instead of Buteo LOG_* macros.…

### DIFF
--- a/mts/common.pri
+++ b/mts/common.pri
@@ -1,3 +1,5 @@
 CONFIG += link_pkgconfig
 PKGCONFIG += systemsettings
 DEFINES += MTP_PLUGINDIR=\\\"$$[QT_INSTALL_LIBS]/mtp\\\"
+
+SOURCES += $$PWD/common/trace.cpp

--- a/mts/common/trace.cpp
+++ b/mts/common/trace.cpp
@@ -1,0 +1,33 @@
+/*
+* This file is part of libmeegomtp package
+*
+* Copyright (C) 2021 Jolla Ltd.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this list
+* of conditions and the following disclaimer. Redistributions in binary form must
+* reproduce the above copyright notice, this list of conditions and the following
+* disclaimer in the documentation and/or other materials provided with the distribution.
+* Neither the name of Nokia Corporation nor the names of its contributors may be
+* used to endorse or promote products derived from this software without specific
+* prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+* OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+* OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*/
+
+#include "trace.h"
+
+Q_LOGGING_CATEGORY(lcMtp, "buteo.mtp", QtWarningMsg)
+

--- a/mts/common/trace.h
+++ b/mts/common/trace.h
@@ -32,9 +32,10 @@
 #ifndef  PRN_TRACE_H
 # define PRN_TRACE_H
 # include <QtGlobal>
-// Use logging macros available in sync-fw
-# include <buteosyncfw5/LogMacros.h>
+# include <QLoggingCategory>
 # include "mts.h"
+
+Q_DECLARE_LOGGING_CATEGORY(lcMtp)
 
 # define MTP_LOG_LEVEL_CRITICAL      1
 # define MTP_LOG_LEVEL_WARNING       2
@@ -47,18 +48,18 @@
 # endif
 
 /*Critical logs always enabled, use selectively*/
-# define MTP_LOG_CRITICAL(msg)     do { LOG_CRITICAL(msg); } while(0)
+# define MTP_LOG_CRITICAL(msg)     do { qCCritical(lcMtp) << msg; } while(0)
 
 # if MTP_LOG_LEVEL < MTP_LOG_LEVEL_WARNING
 #  define MTP_LOG_WARNING(msg)     do {} while(0)
 # else
-#  define MTP_LOG_WARNING(msg)     do { LOG_WARNING(msg); } while(0)
+#  define MTP_LOG_WARNING(msg)     do { qCWarning(lcMtp) << msg; } while(0)
 # endif
 
 # if MTP_LOG_LEVEL < MTP_LOG_LEVEL_INFO
 #  define MTP_LOG_INFO(msg)        do {} while(0)
 # else
-#  define MTP_LOG_INFO(msg)        do { LOG_INFO(msg); } while(0)
+#  define MTP_LOG_INFO(msg)        do { qCInfo(lcMtp) << msg; } while(0)
 # endif
 
 /* Tracing macros should produce output only at the highest log level */
@@ -66,7 +67,7 @@
 # if MTP_LOG_LEVEL < MTP_LOG_LEVEL_TRACE
 #  define MTP_LOG_TRACE(msg)       do {} while(0)
 # else
-#  define MTP_LOG_TRACE(msg)       do { LOG_DEBUG(msg); } while(0)
+#  define MTP_LOG_TRACE(msg)       do { qCDebug(lcMtp) << msg; } while(0)
 # endif
 
 # if MTP_LOG_LEVEL < MTP_LOG_LEVEL_TRACE_EXTRA

--- a/service/service.cpp
+++ b/service/service.cpp
@@ -31,7 +31,7 @@
 #include <QEventLoop>
 #include <QStringList>
 #include <QTimer>
-#include <Logger.h>
+#include <QLoggingCategory>
 #include <MGConfItem>
 #include "mts.h"
 
@@ -67,11 +67,7 @@ int main(int argc, char** argv)
     QCommandLineParser parser;
     parser.setApplicationDescription("standalone buteo-mtp daemon");
     parser.addHelpOption();
-    QCommandLineOption logToHomeOption(QStringList() << "d" << "log-to-home",
-                                       "Log to \"$HOME/mtp.log\".");
-    parser.addOption(logToHomeOption);
     parser.process(app);
-    bool logToHome(parser.isSet(logToHomeOption));
 
     /* Get symlink policy from dconf */
     setupSymLinkPolicy();
@@ -94,16 +90,8 @@ int main(int argc, char** argv)
     bool ok = Mts::getInstance()->activate();
     if( ok )
     {
-        if (logToHome)
-        {
-            Buteo::Logger::createInstance(QDir::homePath() + "/mtp.log", false, 0);
-            if (!Mts::getInstance()->debugLogsEnabled())
-            {
-                Mts::getInstance()->toggleDebugLogs();
-            }
-
-            Buteo::Logger::instance()->enable();
-        }
+        QLoggingCategory lcMtp("buteo.mtp");
+        lcMtp.setEnabled(QtDebugMsg, Mts::getInstance()->debugLogsEnabled());
         app.exec();
     }
     else


### PR DESCRIPTION
… JB#53712

Also remove the log-to-home option as everything is logged via
Qt logging instead.