### PR TITLE
mts_storage_tests breaks build with LTO

### DIFF
--- a/libmeegomtp.pro
+++ b/libmeegomtp.pro
@@ -46,7 +46,7 @@ mts_protocol_tests.depends = sub-mts
 SUBDIRS += \
     mts \
     test \
-    mts_storage_tests \
+#    mts_storage_tests \
     mts_fsstorage_plugin \
     mts_fsstorage_tests \
     mts_deviceinfo_tests \


### PR DESCRIPTION
I am trying to build buteo-mtp with gcc 11.2 on Manjaro Linux and I have following error message:
```
jmlich@manajro-virt:~/workspace/nemo-packaging/buteo-mtp/src/buteo-mtp-0.9.7 (master)$ make
/usr/bin/qmake -o Makefile libmeegomtp.pro
cd mts/ && ( test -e Makefile || /usr/bin/qmake -o Makefile /home/jmlich/workspace/nemo-packaging/buteo-mtp/src/buteo-mtp-0.9.7/mts/mts.pro ) && make -f Makefile 
make[1]: Entering directory '/home/jmlich/workspace/nemo-packaging/buteo-mtp/src/buteo-mtp-0.9.7/mts'
make[1]: Nothing to be done for 'first'.
make[1]: Leaving directory '/home/jmlich/workspace/nemo-packaging/buteo-mtp/src/buteo-mtp-0.9.7/mts'
cd test/ && ( test -e Makefile || /usr/bin/qmake -o Makefile /home/jmlich/workspace/nemo-packaging/buteo-mtp/src/buteo-mtp-0.9.7/test/test.pro ) && make -f Makefile 
make[1]: Entering directory '/home/jmlich/workspace/nemo-packaging/buteo-mtp/src/buteo-mtp-0.9.7/test'
make -f Makefile.Release
make[2]: Entering directory '/home/jmlich/workspace/nemo-packaging/buteo-mtp/src/buteo-mtp-0.9.7/test'
make[2]: Nothing to be done for 'first'.
make[2]: Leaving directory '/home/jmlich/workspace/nemo-packaging/buteo-mtp/src/buteo-mtp-0.9.7/test'
make[1]: Leaving directory '/home/jmlich/workspace/nemo-packaging/buteo-mtp/src/buteo-mtp-0.9.7/test'
cd mts/platform/storage/unittests/ && ( test -e Makefile || /usr/bin/qmake -o Makefile /home/jmlich/workspace/nemo-packaging/buteo-mtp/src/buteo-mtp-0.9.7/mts/platform/storage/unittests/unittests.pro ) && make -f Makefile 
make[1]: Entering directory '/home/jmlich/workspace/nemo-packaging/buteo-mtp/src/buteo-mtp-0.9.7/mts/platform/storage/unittests'
g++ -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -pipe -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -pthread -flto=4 -fno-fat-lto-objects -fuse-linker-plugin -fPIC -o storagefactory-test trace.o storagefactory_test.o storagefactory.o mtpdeviceinfo.o deviceinfoprovider.o xmlhandler.o mtpcontainer.o mtpcontainerwrapper.o mtpextensionmanager.o mtpresponder.o mtprxcontainer.o mtptxcontainer.o objectpropertycache.o propertypod.o mtptransporterdummy.o descriptor.o mtptransporterusb.o threadio.o moc_storagefactory_test.o moc_storagefactory.o moc_storageplugin.o moc_mtpdeviceinfo.o moc_deviceinfoprovider.o moc_mtpresponder.o moc_mtptransporter.o moc_mtptransporterdummy.o moc_mtptransporterusb.o moc_threadio.o   -ldl -lsystemsettings -lQt5DBus -lQt5Core -lprofile -ldbus-1 -lglib-2.0 -lconnman-qt5 -lnemodbus /usr/lib/libQt5Test.so /usr/lib/libQt5Xml.so /usr/lib/libQt5DBus.so /usr/lib/libQt5Core.so -lpthread   
/usr/bin/ld: /tmp/cc9TiJGw.ltrans4.ltrans.o: in function `meegomtp1dot0::MTPResponder::qt_static_metacall(QObject*, QMetaObject::Call, int, void**)':
<artificial>:(.text+0x340d): undefined reference to `BulkReaderThread::interrupt()'
/usr/bin/ld: <artificial>:(.text+0x341c): undefined reference to `BulkReaderThread::interrupt()'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:342: storagefactory-test] Error 1
make[1]: Leaving directory '/home/jmlich/workspace/nemo-packaging/buteo-mtp/src/buteo-mtp-0.9.7/mts/platform/storage/unittests'
make: *** [Makefile:105: sub-mts-storage-tests-make_first] Error 2
```

I must admit that I don't understand this error message and what it caused. It seems the threadio.o is not compiled properly. 

```
$ nm -o --demangle --extern-only --defined-only ./mts/platform/storage/unittests/threadio.o |grep BulkReaderThread
./mts/platform/storage/unittests/threadio.o:00000000 T BulkReaderThread::releaseData(int)
./mts/platform/storage/unittests/threadio.o:00000000 T BulkReaderThread::_markNewData(int, int)
./mts/platform/storage/unittests/threadio.o:00000000 T BulkReaderThread::_getOffset_locked()
./mts/platform/storage/unittests/threadio.o:00000000 T BulkReaderThread::execute()
./mts/platform/storage/unittests/threadio.o:00000000 T BulkReaderThread::getData(char**, int*)
./mts/platform/storage/unittests/threadio.o:00000000 T BulkReaderThread::interrupt()
./mts/platform/storage/unittests/threadio.o:00000000 T BulkReaderThread::resetData()
./mts/platform/storage/unittests/threadio.o:00000000 T BulkReaderThread::BulkReaderThread(QObject*)
./mts/platform/storage/unittests/threadio.o:00000000 T BulkReaderThread::BulkReaderThread(QObject*)
./mts/platform/storage/unittests/threadio.o:00000000 T BulkReaderThread::~BulkReaderThread()
./mts/platform/storage/unittests/threadio.o:00000000 T BulkReaderThread::~BulkReaderThread()
./mts/platform/storage/unittests/threadio.o:00000000 T BulkReaderThread::~BulkReaderThread()
```


I understand, that disabling of the test is not the solution I would merge, but the issues has been disabled in the github settings of the buteo-mpt project. I don't know better way to state the question.